### PR TITLE
Change transferFrom to transfer on send ETH

### DIFF
--- a/packages/kos-sdk/src/chains/ethereum/erc20.rs
+++ b/packages/kos-sdk/src/chains/ethereum/erc20.rs
@@ -26,10 +26,6 @@ const ERC20_CONTRACT_ABI: &str = r#"
     "constant": false,
     "inputs": [
       {
-        "name": "_from",
-        "type": "address"
-      },
-      {
         "name": "_to",
         "type": "address"
       },
@@ -39,7 +35,7 @@ const ERC20_CONTRACT_ABI: &str = r#"
       }
 
     ],
-    "name": "transferFrom",
+    "name": "transfer",
     "outputs": [
         {
             "name": "",
@@ -47,7 +43,7 @@ const ERC20_CONTRACT_ABI: &str = r#"
         }
     ],
     "payable": false,
-        "stateMutability": "nonpayable",
+    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/packages/kos-sdk/src/chains/ethereum/mod.rs
+++ b/packages/kos-sdk/src/chains/ethereum/mod.rs
@@ -253,13 +253,12 @@ impl ETH {
         if !is_eth_token {
             // update contract data for token transfer
             let contract = erc20::get_contract_erc20();
-            let func = contract.function("transferFrom").map_err(|e| {
-                Error::InvalidMessage(format!("failed to get transferFrom function: {}", e))
+            let func = contract.function("transfer").map_err(|e| {
+                Error::InvalidMessage(format!("failed to get transfer function: {}", e))
             })?;
 
             let encoded = func
                 .encode_input(&[
-                    ethabi::Token::Address(addr_sender.into()),
                     ethabi::Token::Address(addr_receiver.into()),
                     ethabi::Token::Uint(
                         U256::from_dec_str(&amount.to_string())

--- a/packages/kos-sdk/src/chains/evm20.rs
+++ b/packages/kos-sdk/src/chains/evm20.rs
@@ -25,6 +25,10 @@ const EVM20_CONTRACT_ABI: &str = r#"
   {
     "constant": false,
     "inputs": [
+      {	
+        "name": "_from",	
+        "type": "address"	
+      },
       {
         "name": "_to",
         "type": "address"
@@ -35,7 +39,7 @@ const EVM20_CONTRACT_ABI: &str = r#"
       }
 
     ],
-    "name": "transfer",
+    "name": "transferFrom",
     "outputs": [
         {
             "name": "",

--- a/packages/kos-sdk/src/chains/evm20.rs
+++ b/packages/kos-sdk/src/chains/evm20.rs
@@ -25,9 +25,9 @@ const EVM20_CONTRACT_ABI: &str = r#"
   {
     "constant": false,
     "inputs": [
-      {	
-        "name": "_from",	
-        "type": "address"	
+      {
+        "name": "_from",
+        "type": "address"
       },
       {
         "name": "_to",


### PR DESCRIPTION
## Description

When sending some tokens on the Ethereum network, allowance errors were occurring due to the use of the `transferFrom` function, which requires prior approval.
I changed it to the ERC-20 `transfer()` function to avoid these errors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have confirmed all checks `make check`
