### PR TITLE
fix to rust up in github action

### DIFF
--- a/.github/actions/rustup/action.yaml
+++ b/.github/actions/rustup/action.yaml
@@ -45,12 +45,10 @@ runs:
         key: rust-toolchain-${{ runner.os }}-stable
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: clippy, rustfmt
+      run: |
+        rustup update --no-self-update stable
+        rustup component add --toolchain stable rustfmt clippy
+        rustup default stable
 
     - if: ${{ steps.cache-rustup.outputs.cache-hit != 'true' }}
       name: Wasm-pack

--- a/.github/actions/rustup/action.yaml
+++ b/.github/actions/rustup/action.yaml
@@ -46,6 +46,7 @@ runs:
 
     - name: Install Rust toolchain
       run: |
+        set -e
         rustup update --no-self-update stable
         rustup component add --toolchain stable rustfmt clippy
         rustup default stable


### PR DESCRIPTION
## Description

Fix to setup `rustup` in GH action.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Streamlined the installation of the Rust toolchain in CI workflows by replacing an external action with direct `rustup` commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->