### PR TITLE
Remove prefix "v" from iOS release

### DIFF
--- a/.github/workflows/publish-ios.yaml
+++ b/.github/workflows/publish-ios.yaml
@@ -73,6 +73,7 @@ jobs:
         run: |
           brew install jq
           TAG_NAME=${GITHUB_REF#refs/tags/}
+          TAG_NAME=${TAG_NAME#v}
           RELEASE_NAME="${{ github.event.release.name }}"
           RELEASE_BODY="${{ github.event.release.body }}"
           PRERELEASE=${{ github.event.release.prerelease }} 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the handling of version tags in the release process by modifying the script to remove the leading 'v' character from the tag name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->