### PR TITLE
Add support for framework usage on iOS simulators running on Intel processors

### DIFF
--- a/packages/kos-mobile/build_clean.sh
+++ b/packages/kos-mobile/build_clean.sh
@@ -14,8 +14,9 @@ clear_ios() {
   cd "$BUILD_HOME"
   rm -rf ios/XCFrameworks
   rm -rf ios/binds
-  rm -rf ios/framework/KOSMobile/aarch64-apple-ios
-  rm -rf ios/framework/KOSMobile/aarch64-apple-ios-sim
+  rm -rf ios/framework/KOSMobile/ios-framework
+  rm -rf ios/framework/KOSMobile/ios-sim-framework
+  rm -f ios/*.a
 }
 
 log_status "cleaning android files..."

--- a/packages/kos-mobile/build_ios.sh
+++ b/packages/kos-mobile/build_ios.sh
@@ -30,53 +30,69 @@ generate_binds() {
 
 generate_xcframework() {
   log_status "generating XCFramework..."
-  cd "$BUILD_HOME"/ios/framework/KOSMobile
+  cd "$BUILD_HOME"/ios
+  rm -f ./*.a
+  cd "$BUILD_HOME"/../../
   for i in $(seq 0 $((${#IOS_ARCHS[@]} - 1))); do
-    rm -rf "${IOS_ARCHS[i]}"
-    mkdir -p "${IOS_ARCHS[i]}"/
-    if [ "${IOS_ARCHS[i]}" = "aarch64-apple-ios" ]; then
-      xcodebuild -project KOSMobile.xcodeproj \
-        -scheme KOSMobile \
-        -configuration Release \
-        -sdk iphoneos \
-        -arch arm64 \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-        SKIP_INSTALL=NO \
-        clean build
-      BUILT_PRODUCTS_DIR=$(xcodebuild -project KOSMobile.xcodeproj \
-        -scheme KOSMobile \
-        -configuration Release \
-        -sdk iphoneos \
-        -arch arm64 \
-        -showBuildSettings |
-        grep "BUILT_PRODUCTS_DIR" |
-        grep -oEi "\/.*")
-      cp -f -r "$BUILT_PRODUCTS_DIR"/* "${IOS_ARCHS[i]}"/
-    elif [ "${IOS_ARCHS[i]}" = "aarch64-apple-ios-sim" ]; then
-      xcodebuild -project KOSMobile.xcodeproj \
-        -scheme KOSMobile \
-        -configuration Release \
-        -sdk iphonesimulator \
-        -arch arm64 \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-        SKIP_INSTALL=NO \
-        clean build
-      BUILT_PRODUCTS_DIR=$(xcodebuild -project KOSMobile.xcodeproj \
-        -scheme KOSMobile \
-        -configuration Release \
-        -sdk iphonesimulator \
-        -arch arm64 \
-        -showBuildSettings |
-        grep "BUILT_PRODUCTS_DIR" |
-        grep -oEi "\/.*")
-      cp -f -r "$BUILT_PRODUCTS_DIR"/* "${IOS_ARCHS[i]}"/
-    fi
+      cp target/"${IOS_ARCHS[i]}"/release/"${IOS_ARCHS[i]}"-lib"$PACKAGE_NAME".a packages/kos-mobile/ios
   done
+  cd "$BUILD_HOME"/ios
+  lipo -create -output ios-sim-lib"$PACKAGE_NAME".a \
+    aarch64-apple-ios-sim-lib"$PACKAGE_NAME".a \
+    x86_64-apple-ios-lib"$PACKAGE_NAME".a
+  mv aarch64-apple-ios-libkos_mobile.a ios-lib"$PACKAGE_NAME".a
+  rm aarch64-apple-ios-sim-lib"$PACKAGE_NAME".a
+  rm x86_64-apple-ios-lib"$PACKAGE_NAME".a
+  cd "$BUILD_HOME"/ios/framework/KOSMobile
+  # Build for physical iOS devices (ARM64)
+  xcodebuild -project KOSMobile.xcodeproj \
+    -scheme KOSMobile \
+    -configuration Release \
+    -sdk iphoneos \
+    -arch arm64 \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO \
+    clean build
+  BUILT_PRODUCTS_DIR=$(xcodebuild -project KOSMobile.xcodeproj \
+    -scheme KOSMobile \
+    -configuration Release \
+    -sdk iphoneos \
+    -arch arm64 \
+    -showBuildSettings |
+    grep "BUILT_PRODUCTS_DIR" |
+    grep -oEi "\/.*")
+  rm -rf ios-framework
+  mkdir ios-framework
+  cp -f -r "$BUILT_PRODUCTS_DIR"/* ios-framework/
+  # Build for simulators
+  xcodebuild -project KOSMobile.xcodeproj \
+    -scheme KOSMobile \
+    -configuration Release \
+    -sdk iphonesimulator \
+    -arch arm64 \
+    -arch x86_64 \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO \
+    clean build
+  BUILT_PRODUCTS_DIR=$(xcodebuild -project KOSMobile.xcodeproj \
+    -scheme KOSMobile \
+    -configuration Release \
+    -sdk iphonesimulator \
+    -arch arm64 \
+    -arch x86_64 \
+    -showBuildSettings |
+    grep "BUILT_PRODUCTS_DIR" |
+    grep -oEi "\/.*")
+  rm -rf ios-sim-framework
+  mkdir ios-sim-framework
+  cp -f -r "$BUILT_PRODUCTS_DIR"/* ios-sim-framework/
   rm -rf ../../XCFrameworks
   mkdir -p ../../XCFrameworks
   xcodebuild -create-xcframework \
-    -framework "${IOS_ARCHS[0]}"/KOSMobile.framework \
-    -framework "${IOS_ARCHS[1]}"/KOSMobile.framework \
+    -framework ios-framework/KOSMobile.framework \
+    -debug-symbols "$BUILD_HOME"/ios/framework/KOSMobile/ios-framework/KOSMobile.framework.dSYM \
+    -framework ios-sim-framework/KOSMobile.framework \
+    -debug-symbols "$BUILD_HOME"/ios/framework/KOSMobile/ios-sim-framework/KOSMobile.framework.dSYM \
     -output ../../XCFrameworks/KOSMobile.xcframework
   cd ../../XCFrameworks
   zip -r -y KOSMobile.xcframework.zip KOSMobile.xcframework

--- a/packages/kos-mobile/build_source.sh
+++ b/packages/kos-mobile/build_source.sh
@@ -16,7 +16,7 @@ ANDROID_JNI=("arm64-v8a" "armeabi-v7a" "x86" "x86_64")
 OPENSSL_VERSION="openssl-3.2.1"
 OPENSSL_PATH="$BUILD_HOME/android/openssl"
 OPENSSL_GENERATED_LIBS_PATH="$OPENSSL_PATH-libs"
-IOS_ARCHS=("aarch64-apple-ios" "aarch64-apple-ios-sim")
+IOS_ARCHS=("aarch64-apple-ios" "aarch64-apple-ios-sim" "x86_64-apple-ios")
 PACKAGE_NAME="kos_mobile"
 
 # colors

--- a/packages/kos-mobile/ios/.gitignore
+++ b/packages/kos-mobile/ios/.gitignore
@@ -1,2 +1,3 @@
 XCFrameworks
 binds
+*.a

--- a/packages/kos-mobile/ios/framework/.gitignore
+++ b/packages/kos-mobile/ios/framework/.gitignore
@@ -37,5 +37,5 @@ xcuserdata/
 !*.xcodeproj/project.pbxproj
 !*.xcodeproj/project.xcworkspace/
 !*.xcodeproj/xcshareddata/
-KOSMobile/aarch64-apple-ios
-KOSMobile/aarch64-apple-ios-sim
+KOSMobile/ios-framework
+KOSMobile/ios-sim-framework

--- a/packages/kos-mobile/ios/framework/KOSMobile/KOSMobile.xcodeproj/project.pbxproj
+++ b/packages/kos-mobile/ios/framework/KOSMobile/KOSMobile.xcodeproj/project.pbxproj
@@ -12,8 +12,8 @@
 		6561E0BF2C76772200907790 /* KOSMobile.h in Headers */ = {isa = PBXBuildFile; fileRef = 6561E0B32C76772200907790 /* KOSMobile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6561E0CB2C76782000907790 /* kos_mobile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6561E0C82C76782000907790 /* kos_mobile.swift */; };
 		6561E0CC2C76782000907790 /* kos_mobileFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = 6561E0CA2C76782000907790 /* kos_mobileFFI.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6561E0CF2C76784A00907790 /* aarch64-apple-ios-sim-libkos_mobile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6561E0CE2C76784A00907790 /* aarch64-apple-ios-sim-libkos_mobile.a */; };
-		6561E0D12C76785700907790 /* aarch64-apple-ios-libkos_mobile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6561E0D02C76785700907790 /* aarch64-apple-ios-libkos_mobile.a */; };
+		65972EF22C874E9C00011338 /* ios-sim-libkos_mobile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 65972EF02C874E9C00011338 /* ios-sim-libkos_mobile.a */; };
+		65972EF32C874E9C00011338 /* ios-libkos_mobile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 65972EF12C874E9C00011338 /* ios-libkos_mobile.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,8 +34,8 @@
 		6561E0C82C76782000907790 /* kos_mobile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = kos_mobile.swift; path = ../../../binds/kos_mobile.swift; sourceTree = "<group>"; };
 		6561E0C92C76782000907790 /* kos_mobileFFI.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = kos_mobileFFI.modulemap; path = ../../../binds/kos_mobileFFI.modulemap; sourceTree = "<group>"; };
 		6561E0CA2C76782000907790 /* kos_mobileFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = kos_mobileFFI.h; path = ../../../binds/kos_mobileFFI.h; sourceTree = "<group>"; };
-		6561E0CE2C76784A00907790 /* aarch64-apple-ios-sim-libkos_mobile.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "aarch64-apple-ios-sim-libkos_mobile.a"; path = "../../../../../target/aarch64-apple-ios-sim/release/aarch64-apple-ios-sim-libkos_mobile.a"; sourceTree = "<group>"; };
-		6561E0D02C76785700907790 /* aarch64-apple-ios-libkos_mobile.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "aarch64-apple-ios-libkos_mobile.a"; path = "../../../../../target/aarch64-apple-ios/release/aarch64-apple-ios-libkos_mobile.a"; sourceTree = "<group>"; };
+		65972EF02C874E9C00011338 /* ios-sim-libkos_mobile.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "ios-sim-libkos_mobile.a"; path = "../../ios-sim-libkos_mobile.a"; sourceTree = "<group>"; };
+		65972EF12C874E9C00011338 /* ios-libkos_mobile.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "ios-libkos_mobile.a"; path = "../../ios-libkos_mobile.a"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -43,8 +43,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6561E0D12C76785700907790 /* aarch64-apple-ios-libkos_mobile.a in Frameworks */,
-				6561E0CF2C76784A00907790 /* aarch64-apple-ios-sim-libkos_mobile.a in Frameworks */,
+				65972EF22C874E9C00011338 /* ios-sim-libkos_mobile.a in Frameworks */,
+				65972EF32C874E9C00011338 /* ios-libkos_mobile.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,8 +100,8 @@
 		6561E0CD2C76784A00907790 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				6561E0D02C76785700907790 /* aarch64-apple-ios-libkos_mobile.a */,
-				6561E0CE2C76784A00907790 /* aarch64-apple-ios-sim-libkos_mobile.a */,
+				65972EF12C874E9C00011338 /* ios-libkos_mobile.a */,
+				65972EF02C874E9C00011338 /* ios-sim-libkos_mobile.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -379,6 +379,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -387,8 +388,8 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				"OTHER_LDFLAGS[sdk=iphoneos*]" = "\"$(SRCROOT)/../../../../../target/aarch64-apple-ios/release/aarch64-apple-ios-libkos_mobile.a\"";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "\"$(SRCROOT)/../../../../../target/aarch64-apple-ios-sim/release/aarch64-apple-ios-sim-libkos_mobile.a\"";
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = "\"$(SRCROOT)/../../ios-libkos_mobile.a\"";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "\"$(SRCROOT)/../../ios-sim-libkos_mobile.a\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.klever.KOSMobile;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -417,6 +418,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -425,8 +427,8 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				"OTHER_LDFLAGS[sdk=iphoneos*]" = "\"$(SRCROOT)/../../../../../target/aarch64-apple-ios/release/aarch64-apple-ios-libkos_mobile.a\"";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "\"$(SRCROOT)/../../../../../target/aarch64-apple-ios-sim/release/aarch64-apple-ios-sim-libkos_mobile.a\"";
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = "\"$(SRCROOT)/../../ios-libkos_mobile.a\"";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "\"$(SRCROOT)/../../ios-sim-libkos_mobile.a\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.klever.KOSMobile;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
This PR adds support for building Rust targeting the x86_64-apple-ios architecture, enabling compatibility with iOS simulators running on Intel processors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the iOS build process by supporting additional architectures, including `x86_64-apple-ios`.
	- Introduced a more organized output structure for built frameworks, improving clarity and management.

- **Bug Fixes**
	- Improved cleanup process to ensure a clean build environment by removing outdated static library files.

- **Documentation**
	- Updated `.gitignore` files to exclude unnecessary static library files from version control.

- **Refactor**
	- Streamlined the build scripts for better maintainability and efficiency in generating XCFrameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->