### PR TITLE
chore: bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "kos"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "kos-mobile"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "hex",
  "kos",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "kos-web"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "enum_delegate",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://klever.org/"
 license = "Apache-2.0"
 repository = "https://github.com/kleverio/kos-rs"
 rust-version = "1.69.0"
-version = "0.2.2"
+version = "0.2.3"
 
 [workspace.dependencies]
 bech32 = "0.9.1"
@@ -50,5 +50,5 @@ log = "0.4"
 lazy_static = "1.4.0"
 thiserror = "1.0"
 
-kos = { version = "0.2.2", path = "./packages/kos", default-features = false }
+kos = { version = "0.2.3", path = "./packages/kos", default-features = false }
 kos-mobile = { version = "0.1.0", path = "./packages/kos-mobile", default-features = false }

--- a/packages/kos/src/chains/mod.rs
+++ b/packages/kos/src/chains/mod.rs
@@ -369,14 +369,14 @@ impl ChainRegistry {
                 constants::DOT,
                 ChainInfo {
                     factory: || Box::new(substrate::Substrate::new(21, 0, "DOT", "Polkadot")),
-                    supported: true,
+                    supported: false,
                 },
             ),
             (
                 constants::KSM,
                 ChainInfo {
                     factory: || Box::new(substrate::Substrate::new(27, 2, "KSM", "Kusama")),
-                    supported: true,
+                    supported: false,
                 },
             ),
             (
@@ -390,28 +390,28 @@ impl ChainRegistry {
                 constants::REEF,
                 ChainInfo {
                     factory: || Box::new(substrate::Substrate::new(29, 42, "REEF", "Reef")),
-                    supported: true,
+                    supported: false,
                 },
             ),
             (
                 constants::SDN,
                 ChainInfo {
                     factory: || Box::new(substrate::Substrate::new(35, 5, "SDN", "Shiden")),
-                    supported: true,
+                    supported: false,
                 },
             ),
             (
                 constants::ASTR,
                 ChainInfo {
                     factory: || Box::new(substrate::Substrate::new(36, 5, "ASTR", "Astar")),
-                    supported: true,
+                    supported: false,
                 },
             ),
             (
                 constants::CFG,
                 ChainInfo {
                     factory: || Box::new(substrate::Substrate::new(47, 36, "CFG", "Centrifuge")),
-                    supported: true,
+                    supported: false,
                 },
             ),
             (
@@ -425,14 +425,14 @@ impl ChainRegistry {
                 constants::KILT,
                 ChainInfo {
                     factory: || Box::new(substrate::Substrate::new(44, 38, "KILT", "KILT")),
-                    supported: true,
+                    supported: false,
                 },
             ),
             (
                 constants::ALTAIR,
                 ChainInfo {
                     factory: || Box::new(substrate::Substrate::new(42, 136, "ALTAIR", "Altair")),
-                    supported: true,
+                    supported: false,
                 },
             ),
             (
@@ -572,7 +572,7 @@ impl ChainRegistry {
                 constants::AVAIL,
                 ChainInfo {
                     factory: || Box::new(substrate::Substrate::new(62, 42, "AVAIL", "Avail")),
-                    supported: true,
+                    supported: false,
                 },
             ),
             (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workspace package version from 0.2.2 to 0.2.3
	- Updated `kos` dependency version from 0.2.2 to 0.2.3
- **Bug Fixes**
	- Removed support for several chains in the `ChainRegistry`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->