### PR TITLE
chore: bump version to 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "kos"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "kos-mobile"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bigdecimal",
  "hex",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "kos-web"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "enum_delegate",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://klever.org/"
 license = "Apache-2.0"
 repository = "https://github.com/kleverio/kos-rs"
 rust-version = "1.69.0"
-version = "0.2.6"
+version = "0.2.7"
 
 [workspace.dependencies]
 bech32 = "0.9.1"
@@ -41,4 +41,4 @@ serde_json = "1.0"
 lazy_static = "1.4.0"
 thiserror = "1.0"
 
-kos = { version = "0.2.6", path = "./packages/kos", default-features = false }
+kos = { version = "0.2.7", path = "./packages/kos", default-features = false }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workspace package version from 0.2.6 to 0.2.7.
  - Updated the dependency version for the kos package from 0.2.6 to 0.2.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->