### PR TITLE
[KLC-1438] Replace klever.finance with klever.org

### DIFF
--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -1,5 +1,5 @@
-const API = "https://api.testnet.klever.finance"
-const NODE = "https://node.testnet.klever.finance"
+const API = "https://api.testnet.klever.org"
+const NODE = "https://node.testnet.klever.org"
 function debugWallet(tag, w) {
   let data = JSON.stringify({chain: w.getChain(), baseChain: w.getBaseChain().getName(), address: w.getAddress(), privateKey: w.getPrivateKey(), publicKey: w.getPublicKey(), mnemonic: w.getMnemonic(), path: w.getPath()})
   document.getElementById("demo").innerHTML += "<br><b>"+tag+":</b>"+data+"<br>";


### PR DESCRIPTION
This PR updates all references from the legacy `.finance` domain to the new `.org` domain. The `.finance` domain will be decommissioned at the end of April, making this change necessary to ensure continued functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated external service URLs for API and node interactions to ensure reliable connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->