### PR TITLE
get kos-hardware version from cargo env

### DIFF
--- a/packages/kos-hardware/src/lib.rs
+++ b/packages/kos-hardware/src/lib.rs
@@ -384,7 +384,7 @@ pub extern "C" fn rs_tx_info_to_json(info: &mut CTxInfo, result: &mut CBuffer) -
     true
 }
 
-pub const VERSION: &str = "Library Version: 0.2.27";
+pub const VERSION: &str = concat!("\nLibrary Version: ", env!("CARGO_PKG_VERSION"), "\n");
 
 #[no_mangle]
 pub extern "C" fn get_version() -> *const u8 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The displayed library version now automatically reflects the current package version.
* **Style**
  * The version string is now formatted with newlines before and after the version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->