### PR TITLE
chore: bump version to 0.2.31 in Cargo.toml and Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "kos"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "kos-codec"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "alloy-dyn-abi",
  "base32",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "kos-hardware"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "kos",
  "tiny-json-rs",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "kos-mobile"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "kos-web"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "enum_delegate",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ homepage = "https://klever.org/"
 license = "Apache-2.0"
 repository = "https://github.com/kleverio/kos-rs"
 rust-version = "1.74.0"
-version = "0.2.30"
+version = "0.2.31"
 
 [workspace.dependencies]
 bech32 = "0.9.1"
@@ -77,7 +77,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 kos-mobile = { version = "0.1.0", path = "./packages/kos-mobile", default-features = false }
 ecies = { version = "0.2.7", default-features = false, features = ["pure"] }
-kos = { version = "0.2.30", path = "./packages/kos", default-features = false, features = ["not-ksafe"] }
+kos = { version = "0.2.31", path = "./packages/kos", default-features = false, features = ["not-ksafe"] }
 
 # lightning
 lwk_common = "0.9.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package version and synchronized workspace dependency versions to the latest patch level for consistency and maintenance.
  * No user-facing changes: functionality, behavior, and APIs remain unchanged.
  * Existing workflows and integrations continue to operate as before; no migration or configuration updates are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->