### PR TITLE
add algorithm prefix to substrate sig

### DIFF
--- a/packages/kos-mobile/src/lib.rs
+++ b/packages/kos-mobile/src/lib.rs
@@ -738,7 +738,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(transaction.raw.len(), 284, "The raw length doesn't match");
+        assert_eq!(transaction.raw.len(), 286, "The raw length doesn't match");
     }
     #[test]
     fn should_sign_raw_transaction_icp() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Substrate signatures now use MultiSignature encoding with a type prefix, improving compatibility with multisig and multiple key types.

- Tests
  - Updated Substrate tests to validate the new MultiSignature format.
  - Adjusted Stellar (XLM) raw transaction signing test to reflect the updated output length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->