### PR TITLE
bump version to 0.2.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "kos"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "kos-codec"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "alloy-dyn-abi",
  "base32",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "kos-hardware"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "kos",
  "tiny-json-rs",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "kos-mobile"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "kos-web"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "enum_delegate",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ homepage = "https://klever.org/"
 license = "Apache-2.0"
 repository = "https://github.com/kleverio/kos-rs"
 rust-version = "1.74.0"
-version = "0.2.32"
+version = "0.2.33"
 
 [workspace.dependencies]
 bech32 = "0.9.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Incremented application version to 0.2.33 for release packaging and distribution alignment.
  * No functional, UX, or performance changes included in this release.
  * Public APIs remain unchanged; full backward compatibility is maintained.
  * Existing configurations and integrations require no action; upgrade is safe.
  * Internal housekeeping only; no impact on end-user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->